### PR TITLE
Make test pass - method 1

### DIFF
--- a/staking/src/staking.rs
+++ b/staking/src/staking.rs
@@ -308,11 +308,6 @@ pub trait StakingContract {
         let package_info = self.package_info(&staker_info.package_name).get();
 
         require!(
-            staker_info.premature_unstake_timestamp == 0,
-            "cannot call premature unstake more than once"
-        );
-
-        require!(
             package_info.penalty_seconds != 0 || package_info.penalty_fee != 0,
             "the package has no penalties so premature unstake is not available"
         );


### PR DESCRIPTION
Removing the `require` statement should not influence the tests in any way because the `require` is not exercised by the tests. 

However, removing the `require` statement makes the test pass for some reason. It looks like a glitch in the compiler because the logic changes after the code is compiled. What you write is not actually what gets compiled...

How to reproduce:
`erdpy contract build` and then `erdpy contract test`.

Erdpy version: `erdpy 2.1.0`

Line that's failing: 263